### PR TITLE
feat: add deployment scaling and cleanup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ go.work.sum
 .DS_Store
 
 # no docker image files under git
-docker-image-*.tar
+oauth2-server*.tar
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added deployment management scripts:
+  - `scale.sh` for scaling the OAuth2 server deployment
+  - `undeploy.sh` for removing the deployment
 - Added golangci-lint configuration for code quality
 - Added Makefile with common development commands
 - Added comprehensive token introspection endpoint tests

--- a/deployment/local/README.md
+++ b/deployment/local/README.md
@@ -8,53 +8,80 @@ This directory contains scripts and configurations for deploying the OAuth2 serv
 - kubectl
 - k3d (Lightweight Kubernetes distribution)
 
-## Preparations (One-time Setup)
+## Available Scripts
 
-These steps only need to be performed once when setting up the development environment:
+### Cluster Management
+- `manage-cluster.sh`: Manages the k3d cluster
+  - `./manage-cluster.sh create`: Creates a new cluster with port 8080 mapped to the loadbalancer
+  - `./manage-cluster.sh delete`: Deletes the cluster
+  - `./manage-cluster.sh status`: Checks if the cluster is running
 
-1. Create a local Kubernetes cluster:
-   ```bash
-   ./manage-cluster.sh create
-   ```
-   This creates a k3d cluster with port 8080 mapped to the loadbalancer.
+### Deployment
+- `deploy.sh`: Deploys the OAuth2 server to the cluster
+  - Loads the Docker image into the cluster
+  - Applies Kubernetes manifests
+  - Creates necessary resources
 
-2. Set up the JWT secret:
-   ```bash
-   ./setup-secret.sh
-   ```
-   This script creates a Kubernetes secret from the first private key found in the keytool directory.
+- `undeploy.sh`: Removes the OAuth2 server deployment
+  - Deletes the deployment from the cluster
+  - Useful for clean removal without deleting the cluster
 
-   Note: Only run this again if:
-   - Creating a new cluster
-   - Updating the secret with a new key
-   - If the secret was accidentally deleted
+- `scale.sh`: Scales the OAuth2 server deployment
+  - Usage: `REPLICAS=2 ./scale.sh`
+  - Adjusts the number of running pods
+  - Requires REPLICAS environment variable
+
+### Image Management
+- `rebuildServerImage.sh`: Builds and saves the Docker image
+  - Builds the server image
+  - Saves it as a tar file for local use
+  - Run this after code changes
+
+### Configuration
+- `setup-secret.sh`: Sets up the JWT signing key
+  - Creates a Kubernetes secret from the first private key in keytool
+  - Only needed for initial setup or key changes
+
+### Verification
+- `check-deployment.sh`: Verifies the deployment
+  - Checks pod status and readiness
+  - Verifies service availability
+  - Tests loadbalancer and port-forwarding
+  - Validates JWKS endpoint
+
+- `port-forward.sh`: Sets up port forwarding
+  - Forwards local port 8080 to the service
+  - Alternative to loadbalancer access
 
 ## Development Flow
 
-These are the steps you'll repeat during development:
-
-1. Build and save the Docker image (after code changes):
+1. **Initial Setup** (one-time):
    ```bash
+   ./manage-cluster.sh create
+   ./setup-secret.sh
+   ```
+
+2. **Development Cycle**:
+   ```bash
+   # After code changes
    ./rebuildServerImage.sh
-   ```
-   This script builds the Docker image and saves it as a tar file for local use.
-
-2. Deploy the application:
-   ```bash
    ./deploy.sh
-   ```
-   This script loads the saved image into the cluster and applies the Kubernetes manifests.
-
-3. Verify the deployment:
-   ```bash
    ./check-deployment.sh
    ```
-   This script checks:
-   - Pod status and readiness
-   - Service availability
-   - Service accessibility through the k3d loadbalancer
-   - Service accessibility via port-forwarding
-   - JWKS endpoint availability
+
+3. **Scaling** (if needed):
+   ```bash
+   REPLICAS=2 ./scale.sh
+   ```
+
+4. **Cleanup**:
+   ```bash
+   # Remove deployment
+   ./undeploy.sh
+
+   # Or remove entire cluster
+   ./manage-cluster.sh delete
+   ```
 
 ## Security Notes
 
@@ -63,32 +90,22 @@ These are the steps you'll repeat during development:
 
 ## Service Access
 
-The OAuth2 server is exposed as a LoadBalancer service, which means:
-- It's accessible through the k3d loadbalancer at `http://localhost:8080`
-- The service is also accessible via port-forwarding:
-  ```bash
-  kubectl port-forward svc/oauth2-server 8080:8080
-  ```
-- The JWKS endpoint is available at `http://localhost:8080/.well-known/jwks.json`
-
-## Cleanup
-
-To remove the deployment and cluster:
-```bash
-./manage-cluster.sh delete
-```
+The OAuth2 server is exposed as a LoadBalancer service:
+- Access via k3d loadbalancer: `http://localhost:8080`
+- Access via port-forwarding: `kubectl port-forward svc/oauth2-server 8080:8080`
+- JWKS endpoint: `http://localhost:8080/.well-known/jwks.json`
 
 ## Troubleshooting
 
 If you encounter issues:
-1. Check that the cluster is running: `k3d cluster list`
-2. Verify the secret exists: `kubectl get secret jwt-key`
+1. Check cluster status: `k3d cluster list`
+2. Verify secret: `kubectl get secret jwt-key`
 3. Check pod logs: `kubectl logs -l app=oauth2-server`
 4. Check pod status: `kubectl get pods -l app=oauth2-server`
 5. Check service status: `kubectl get svc oauth2-server`
-6. Run the deployment check: `./check-deployment.sh`
+6. Run deployment check: `./check-deployment.sh`
 
 Common issues:
-- If the service is not accessible, check that the k3d loadbalancer is running: `docker ps | grep k3d`
-- If you get a 404 error, verify that the pod is running and the service is configured correctly
-- If you need to recreate the cluster, run `./manage-cluster.sh delete` followed by `./manage-cluster.sh create`
+- Service not accessible: Check k3d loadbalancer with `docker ps | grep k3d`
+- 404 errors: Verify pod and service configuration
+- Cluster recreation: Run `./manage-cluster.sh delete` followed by `./manage-cluster.sh create`

--- a/deployment/local/scale.sh
+++ b/deployment/local/scale.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Check if REPLICAS is set
+if [ -z "${REPLICAS:-}" ]; then
+    echo "Error: REPLICAS environment variable is not set"
+    echo "Usage: REPLICAS=2 ./scale.sh"
+    exit 1
+fi
+
+echo "Scaling OAuth2 server to ${REPLICAS} replicas..."
+
+# Scale the deployment
+kubectl scale deployment oauth2-server --replicas="${REPLICAS}" -n default
+
+echo "OAuth2 server scaled successfully to ${REPLICAS} replicas."

--- a/deployment/local/undeploy.sh
+++ b/deployment/local/undeploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Undeploying OAuth2 server..."
+
+# Delete the deployment
+kubectl delete deployment oauth2-server -n default
+
+echo "OAuth2 server undeployed successfully."


### PR DESCRIPTION
# Add Deployment Scaling and Cleanup Scripts

This PR adds new deployment management scripts to improve the local development experience with k3d.

## Changes

### Added
- `scale.sh`: Script to scale the OAuth2 server deployment
  - Uses REPLICAS environment variable
  - Provides clear feedback on scaling operations
  - Includes error handling for missing REPLICAS variable

- `undeploy.sh`: Script to remove the OAuth2 server deployment
  - Clean removal of deployment without deleting the cluster
  - Useful for development and testing scenarios

### Documentation
- Updated deployment/local/README.md with:
  - New script documentation
  - Improved organization of available scripts
  - Clear usage instructions
  - Better development flow documentation

### Changelog
- Updated CHANGELOG.md with new deployment management features
- Maintained LIFO order in changelog entries

## Testing
- Verified script functionality with different replica counts
- Tested undeployment and redeployment workflow
- Confirmed proper error handling in scale script

## Checklist
- [x] Scripts are executable
- [x] Documentation is updated
- [x] Changelog is updated
- [x] Error handling is implemented
- [x] Scripts follow project conventions
